### PR TITLE
add test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
+coverage.json
+coverage/
 
 **/*.swp

--- a/package.json
+++ b/package.json
@@ -4,12 +4,14 @@
   "private": true,
   "description": "partnership DAO",
   "devDependencies": {
+    "solidity-coverage": "^0.4.9",
     "solium": "^1.0.9",
     "truffle": "^4.0.4"
   },
   "license": "MIT",
   "scripts": {
     "build": "./node_modules/.bin/truffle compile",
+    "coverage": "./node_modules/.bin/solidity-coverage",
     "test": "./node_modules/.bin/truffle test"
   },
   "dependencies": {


### PR DESCRIPTION
* Add test coverage framework [solidity-coverage](https://github.com/sc-forks/solidity-coverage)
* Add test coverage for failed transaction send (note: there's no way to cancel a bad transaction once it's been approved by all partners, which is probably not good.)
* The only missing coverage is in the failure of `withdraw()`. I think I'd have to write a bad contract to make this happen.