### PR TITLE
Code coverage enforced

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
 language: node_js
 node_js:
   - "7"
+install:
+  - npm install -g truffle
+  - npm install -g ganache-cli
+  - npm install
+script:
+  - npm test
+before_script:
+  - testrpc > /dev/null &
+  - sleep 5
+after_script:
+  - npm run coverage && cat coverage/lcov.info | coveralls

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 A DAO for a simple partnership, written in Solidity for deployment on Ethereum.
 
+It uses the Truffle framework for testing, but does not use its deployment system.
+
 # Installation
 
     $ npm install

--- a/contracts/Incomplete.sol
+++ b/contracts/Incomplete.sol
@@ -1,0 +1,26 @@
+/// Incomplete: a test contract for Partnership
+/// Doesn't allow deposits after the first time, allows proxy calls.
+pragma solidity ^0.4.18;
+contract Incomplete
+{
+  // The fund can only receive money once
+  bool public once;
+
+  function Incomplete() public {
+    once = true;
+  }
+
+  // Used to call Partnership.withdrawal in a failure condition
+  function run(uint value, bytes data) public {
+    require(this.call.value(value)(data));
+  }
+
+  // This executes when funds are sent to the contract
+  function() public payable {
+    require(once);
+
+    // Fail forevermore
+    once = false;
+  }
+}
+

--- a/contracts/Partnership.sol
+++ b/contracts/Partnership.sol
@@ -286,14 +286,11 @@ contract Partnership
 		// mark the withdrawal as successful
 		withdrawableAmounts[msg.sender] -= _amount;
 
-		// send the wei
-		if (msg.sender.send(_amount)) {
-			Withdrawal(msg.sender, _amount);
-		}
-		else {
-			// roll back if the send failed
-			withdrawableAmounts[msg.sender] += _amount;
-		}
+		// Log the withdrawal
+		Withdrawal(msg.sender, _amount);
+
+		// send the wei; if this fails the transaction fails.
+		require(msg.sender.send(_amount));
 	}
 	
 	/// Dissolve DAO and send the remaining ETH to a beneficiary

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "partnership DAO",
   "devDependencies": {
+    "coveralls": "^3.0.0",
     "solidity-coverage": "^0.4.9",
     "solium": "^1.0.9",
     "truffle": "^4.0.4"


### PR DESCRIPTION
* Added test scenario for failed `Partnership.withdraw()` and a new test contract `Incomplete`
* Changed Partnership.withdraw() to use `require` and revert on failure, as `send` doesn't return failure reliably (or at all).
* Set up solidity-coverage
* Set up Travis to run code coverage
* Use coveralls.io
